### PR TITLE
fix animated sprinte image order

### DIFF
--- a/sprite_object.py
+++ b/sprite_object.py
@@ -82,7 +82,7 @@ class AnimatedSprite(SpriteObject):
 
     def get_images(self, path):
         images = deque()
-        for file_name in os.listdir(path):
+        for file_name in sorted(os.listdir(path)):
             if os.path.isfile(os.path.join(path, file_name)):
                 img = pg.image.load(path + '/' + file_name).convert_alpha()
                 images.append(img)


### PR DESCRIPTION
closes #2
sort filenames when listing the animation directory