### PR TITLE
update pygame dependency to pygame-ce

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pygame
+pygame-ce


### PR DESCRIPTION
pip failed to install pygame on Python 3.14 because it attempted a Windows source build that depends on MSVC/distutils and SDL build dependencies. The build stopped with missing distutils.msvccompiler / setuptools._distutils.msvccompiler modules.

This PR replaces pygame with pygame-ce in . pygame-ce provides prebuilt wheels for Python 3.14 and remains drop-in compatible with pygame, avoiding the failing source-build path on Windows.